### PR TITLE
Enable the "modified" date range fields in differential search, and set a default on the default view

### DIFF
--- a/src/applications/differential/query/DifferentialRevisionSearchEngine.php
+++ b/src/applications/differential/query/DifferentialRevisionSearchEngine.php
@@ -113,13 +113,13 @@ final class DifferentialRevisionSearchEngine
       id(new PhabricatorSearchDateField())
         ->setLabel(pht('Modified After'))
         ->setKey('modifiedStart')
-        ->setIsHidden(true)
+        ->setIsHidden(false)
         ->setDescription(
           pht('Find revisions modified at or after a particular time.')),
       id(new PhabricatorSearchDateField())
         ->setLabel(pht('Modified Before'))
         ->setKey('modifiedEnd')
-        ->setIsHidden(true)
+        ->setIsHidden(false)
         ->setDescription(
           pht('Find revisions modified at or before a particular time.')),
       id(new PhabricatorSearchStringListField())

--- a/src/applications/home/view/PHUIHomeView.php
+++ b/src/applications/home/view/PHUIHomeView.php
@@ -86,7 +86,8 @@ final class PHUIHomeView
     $panel = $this->newQueryPanel()
       ->setName(pht('Active Revisions'))
       ->setProperty('class', 'DifferentialRevisionSearchEngine')
-      ->setProperty('key', 'active');
+      ->setProperty('key', 'active')
+      ->setProperty('modifiedStart', '30 days ago');
 
     return $this->renderPanel($panel);
   }


### PR DESCRIPTION
Post layoffs, we have large numbers of stale diffs that clutter up *everyone's* default Phabricator view.  This set of changes will let us search for things based upon how recently they were modified, and set a default of "30 days ago" in the default view.