### PR TITLE
[commit-rendering] include project tags in commit template

### DIFF
--- a/src/applications/differential/field/DifferentialTagsCommitMessageField.php
+++ b/src/applications/differential/field/DifferentialTagsCommitMessageField.php
@@ -22,7 +22,7 @@ final class DifferentialTagsCommitMessageField
   }
 
   public function isTemplateField() {
-    return false;
+    return true;
   }
 
   public function parseFieldValue($value) {


### PR DESCRIPTION
Summary: This is expected to include project tags in the commit message that is fetched by PHLQ

Test Plan: Deploy to Phabricator staging and use https://secure.phabricator.com/conduit/method/differential.getcommitmessage/ to view rendering
