### PR TITLE
[phabricator] allow exposing current action to search

### DIFF
--- a/src/applications/differential/engineextension/DifferentialReviewersSearchEngineAttachment.php
+++ b/src/applications/differential/engineextension/DifferentialReviewersSearchEngineAttachment.php
@@ -13,10 +13,12 @@ final class DifferentialReviewersSearchEngineAttachment
 
   public function willLoadAttachmentData($query, $spec) {
     $query->needReviewers(true);
+    $query->needActiveDiffs(true);
   }
 
   public function getAttachmentForObject($object, $data, $spec) {
     $reviewers = $object->getReviewers();
+    $diff_phid = $object->getActiveDiff()->getPHID();
 
     $status_blocking = DifferentialReviewerStatus::STATUS_BLOCKING;
 
@@ -30,6 +32,7 @@ final class DifferentialReviewersSearchEngineAttachment
         'status' => $status,
         'isBlocking' => $is_blocking,
         'actorPHID' => $reviewer->getLastActorPHID(),
+        'isCurrentAction' => $reviewer->isCurrentAction($diff_phid),
       );
     }
 

--- a/src/applications/differential/storage/DifferentialReviewer.php
+++ b/src/applications/differential/storage/DifferentialReviewer.php
@@ -134,7 +134,7 @@ final class DifferentialReviewer
     return false;
   }
 
-  private function isCurrentAction($diff_phid) {
+  public function isCurrentAction($diff_phid) {
     if (!$diff_phid) {
       return true;
     }


### PR DESCRIPTION
This allows us to see if a user's acceptance is of the most recent change, or if changes have been made after acceptance 

Adapted logic from initial revision of this feature
https://secure.phabricator.com/D17633