### PR TITLE
[custom fields] Call setObject before shouldEnableForRole

### DIFF
--- a/src/infrastructure/customfield/field/PhabricatorCustomField.php
+++ b/src/infrastructure/customfield/field/PhabricatorCustomField.php
@@ -79,6 +79,10 @@ abstract class PhabricatorCustomField extends Phobject {
         $role,
         $fields);
 
+      foreach ($fields as $field) {
+        $field->setObject($object);
+      }
+
       foreach ($fields as $key => $field) {
         // NOTE: We perform this filtering in "buildFieldList()", but may need
         // to filter again after subtype adjustment.
@@ -91,10 +95,6 @@ abstract class PhabricatorCustomField extends Phobject {
           unset($fields[$key]);
           continue;
         }
-      }
-
-      foreach ($fields as $field) {
-        $field->setObject($object);
       }
 
       $field_list = new PhabricatorCustomFieldList($fields);


### PR DESCRIPTION
By calling `setObject` before `shouldEnableForRole`, we allow methods like `shouldAppearInListView` in a `PhabricatorCustomField` subclass to access `getObject()` -- and more importantly, `getObject()->getRepository()`.

This will allow a custom field to use information about the current repository to decide whether it should be shown or hidden.

If the field is indeed disabled, the `unset` later should clear up everything from `$field`, including its `$object` reference.